### PR TITLE
feat(potion-ui): create input field

### DIFF
--- a/packages/potion-ui/package.json
+++ b/packages/potion-ui/package.json
@@ -19,6 +19,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@headlessui/react": "^2.1.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "react": "^18.3.1",

--- a/packages/potion-ui/src/components/InputField/InputField.stories.tsx
+++ b/packages/potion-ui/src/components/InputField/InputField.stories.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { InputField } from "./";
+
+const meta: Meta<typeof InputField> = {
+  title: "Components/InputField",
+  component: InputField,
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default"],
+      description: "The variant of the input component",
+    },
+  },
+  parameters: {
+    componentSubtitle:
+      "A light wrapper around the native input element that handles tedious accessibility concerns and provides more opinionated states for things like hover and focus.",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InputField>;
+
+export const Default: Story = {
+  args: {
+    variant: "default",
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <InputField />
+    </div>
+  ),
+};

--- a/packages/potion-ui/src/components/InputField/InputField.stories.tsx
+++ b/packages/potion-ui/src/components/InputField/InputField.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FaCoffee, FaHeart, FaBasketballBall } from "react-icons/fa";
 import { Meta, StoryObj } from "@storybook/react";
 import { InputField } from "./";
 
@@ -12,6 +12,30 @@ const meta: Meta<typeof InputField> = {
       description: "The variant of the input component",
     },
     size: { control: "select", options: ["normal", "small", "large"] },
+    iconLeft: {
+      options: ["None", "Heart", "Coffee", "Ball"],
+      mapping: {
+        None: undefined,
+        Heart: FaHeart,
+        Coffee: FaCoffee,
+        Ball: FaBasketballBall,
+      },
+      control: {
+        type: "select",
+      },
+    },
+    iconRight: {
+      options: ["None", "Heart", "Coffee", "Ball"],
+      mapping: {
+        None: undefined,
+        Heart: FaHeart,
+        Coffee: FaCoffee,
+        Ball: FaBasketballBall,
+      },
+      control: {
+        type: "select",
+      },
+    },
   },
   parameters: {
     componentSubtitle:
@@ -28,5 +52,111 @@ export const Default: Story = {
     label: "Potion name",
     description: "Give your potion an awesome name",
     placeholder: "potion name here..."
+  },
+};
+
+
+export const WithError: Story = {
+  args: {
+    ...Default.args,
+    variant: "error",
+    errorMessage: "This field is required",
+    value: "",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    ...Default.args,
+    size: "small",
+    label: "Small Input",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    ...Default.args,
+    size: "large",
+    label: "Large Input",
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    ...Default.args,
+    iconLeft: FaCoffee,
+    label: "Coffee Input",
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    ...Default.args,
+    iconRight: FaHeart,
+    label: "Favorite Input",
+  },
+};
+
+export const WithBothIcons: Story = {
+  args: {
+    ...Default.args,
+    iconLeft: FaCoffee,
+    iconRight: FaHeart,
+    label: "Coffee Love",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    disabled: true,
+    label: "Disabled Input",
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    ...Default.args,
+    label: undefined,
+    placeholder: "No label input",
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    ...Default.args,
+    description: undefined,
+    label: "No Description Input",
+  },
+};
+
+export const FullyConfigured: Story = {
+  args: {
+    variant: "default",
+    size: "normal",
+    label: "Fully Configured Input",
+    description: "This input has all properties set",
+    placeholder: "Type here...",
+    iconLeft: FaCoffee,
+    iconRight: FaHeart,
+    errorMessage: "Sample error message",
+  },
+};
+
+export const Password: Story = {
+  args: {
+    ...Default.args,
+    type: "password",
+    label: "Password Input",
+    placeholder: "Enter your password",
+  },
+};
+
+export const Number: Story = {
+  args: {
+    ...Default.args,
+    type: "number",
+    label: "Number Input",
+    placeholder: "Enter a number",
   },
 };

--- a/packages/potion-ui/src/components/InputField/InputField.stories.tsx
+++ b/packages/potion-ui/src/components/InputField/InputField.stories.tsx
@@ -8,9 +8,10 @@ const meta: Meta<typeof InputField> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["default"],
+      options: ["default", "error"],
       description: "The variant of the input component",
     },
+    size: { control: "select", options: ["normal", "small", "large"] },
   },
   parameters: {
     componentSubtitle:
@@ -24,13 +25,8 @@ type Story = StoryObj<typeof InputField>;
 export const Default: Story = {
   args: {
     variant: "default",
+    label: "Potion name",
+    description: "Give your potion an awesome name",
+    placeholder: "potion name here..."
   },
-};
-
-export const AllVariants: Story = {
-  render: () => (
-    <div className="space-y-4">
-      <InputField />
-    </div>
-  ),
 };

--- a/packages/potion-ui/src/components/InputField/index.tsx
+++ b/packages/potion-ui/src/components/InputField/index.tsx
@@ -5,15 +5,23 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib";
 
 const inputVariants = cva(
-  "flex flex-row space-x-2 items-center justify-center rounded-[3px] transition-all duration-300",
+  "flex flex-row space-x-2 items-center justify-center bg-white text-ink-50 focus-within:text-ink-300 border rounded-[3px] transition-all duration-300",
   {
     variants: {
       variant: {
         default:
-          "bg-white text-ink-50 border border-cloud-700 focus:text-ink-300 focus:border-blue-300 focus-within:border-blue-300 focus-within:shadow-input",
+          "border-cloud-700 focus-within:border-blue-300 focus-within:shadow-input",
+        error:
+          "border-red-500 focus-within:border-red-600 focus-within:shadow-input-error",
       },
       size: {
+        small: "px-2 py-2 text-sm mt-1 w-full",
         normal: "px-3 py-3 text-base mt-1 w-full",
+        large: "px-4 py-4 text-lg mt-1 w-full",
+      },
+      isDisabled: {
+        true: "bg-cloud-300 border-cloud-700 text-ink-50 cursor-not-allowed",
+        false: "",
       },
     },
     defaultVariants: {
@@ -25,41 +33,68 @@ const inputVariants = cva(
 
 export interface InputFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
-    VariantProps<typeof inputVariants> {}
+    VariantProps<typeof inputVariants> {
+  label?: string;
+  description?: string;
+  errorMessage?: string;
+  iconLeft?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  iconRight?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
 
 export const InputField: React.FC<InputFieldProps> = ({
   className,
   variant,
   size,
+  label,
+  description,
+  errorMessage,
+  iconLeft: IconLeft,
+  iconRight: IconRight,
   ...props
 }) => {
   return (
     <Field>
-      <Label className="data-[disabled]:opacity-50">
-        <Typography className="font-semibold text-base text-ink-700">
-          Field label
-        </Typography>
-      </Label>
-      <Description className="data-[disabled]:opacity-50">
-        <Typography variant="small" className="text-ink-100">
-          Use your real name so people will recognize you.
-        </Typography>
-      </Description>
-      <div className={cn(inputVariants({ variant, size, className }))}>
-        <div className="w-5 h-5 bg-slate-700" />
+      {label && (
+        <Label>
+          <Typography className="font-semibold text-base text-ink-700">
+            {label}
+          </Typography>
+        </Label>
+      )}
+      {description && (
+        <Description>
+          <Typography variant="small" className="text-ink-100">
+            {description}
+          </Typography>
+        </Description>
+      )}
+      <div
+        className={cn(
+          inputVariants({
+            variant,
+            size,
+            className,
+            isDisabled: props.disabled,
+          })
+        )}
+      >
+        {IconLeft && <IconLeft className="w-5 h-5" />}
         <Input
           {...props}
-          name="full_name"
-          placeholder="Mohammed"
-          className="w-full focus:outline-none"
+          aria-describedby={
+            description ? description : errorMessage ? errorMessage : undefined
+          }
+          className="w-full focus:outline-none disabled:bg-transparent disabled:cursor-not-allowed"
         />
-        <div className="w-5 h-5 bg-slate-700" />
+        {IconRight && <IconRight className="w-5 h-5" />}
       </div>
-      <Description className="data-[disabled]:opacity-50">
-        <Typography variant="small" className="text-red-300">
-          you entered a non valid name!
-        </Typography>
-      </Description>
+      {errorMessage && (
+        <Description>
+          <Typography variant="small" className="text-red-300">
+            {errorMessage}
+          </Typography>
+        </Description>
+      )}
     </Field>
   );
 };

--- a/packages/potion-ui/src/components/InputField/index.tsx
+++ b/packages/potion-ui/src/components/InputField/index.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Description, Field, Input, Label } from "@headlessui/react";
+import { Typography } from "../Typography";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib";
+
+const inputVariants = cva(
+  "flex flex-row space-x-2 items-center justify-center rounded-[3px] transition-all duration-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-white text-ink-50 border border-cloud-700 focus:text-ink-300 focus:border-blue-300 focus-within:border-blue-300 focus-within:shadow-input",
+      },
+      size: {
+        normal: "px-3 py-3 text-base mt-1 w-full",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "normal",
+    },
+  }
+);
+
+export interface InputFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    VariantProps<typeof inputVariants> {}
+
+export const InputField: React.FC<InputFieldProps> = ({
+  className,
+  variant,
+  size,
+  ...props
+}) => {
+  return (
+    <Field>
+      <Label className="data-[disabled]:opacity-50">
+        <Typography className="font-semibold text-base text-ink-700">
+          Field label
+        </Typography>
+      </Label>
+      <Description className="data-[disabled]:opacity-50">
+        <Typography variant="small" className="text-ink-100">
+          Use your real name so people will recognize you.
+        </Typography>
+      </Description>
+      <div className={cn(inputVariants({ variant, size, className }))}>
+        <div className="w-5 h-5 bg-slate-700" />
+        <Input
+          {...props}
+          name="full_name"
+          placeholder="Mohammed"
+          className="w-full focus:outline-none"
+        />
+        <div className="w-5 h-5 bg-slate-700" />
+      </div>
+      <Description className="data-[disabled]:opacity-50">
+        <Typography variant="small" className="text-red-300">
+          you entered a non valid name!
+        </Typography>
+      </Description>
+    </Field>
+  );
+};

--- a/packages/potion-ui/src/components/InputField/index.tsx
+++ b/packages/potion-ui/src/components/InputField/index.tsx
@@ -31,6 +31,19 @@ const inputVariants = cva(
   }
 );
 
+const iconVariants = cva("", {
+  variants: {
+    size: {
+      small: "w-3 h-3",
+      normal: "w-4 h-4",
+      large: "w-5 h-5",
+    },
+  },
+  defaultVariants: {
+    size: "normal",
+  },
+});
+
 export interface InputFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
     VariantProps<typeof inputVariants> {
@@ -78,7 +91,7 @@ export const InputField: React.FC<InputFieldProps> = ({
           })
         )}
       >
-        {IconLeft && <IconLeft className="w-5 h-5" />}
+        {IconLeft && <IconLeft className={cn(iconVariants({ size }))} />}
         <Input
           {...props}
           aria-describedby={
@@ -86,7 +99,7 @@ export const InputField: React.FC<InputFieldProps> = ({
           }
           className="w-full focus:outline-none disabled:bg-transparent disabled:cursor-not-allowed"
         />
-        {IconRight && <IconRight className="w-5 h-5" />}
+        {IconRight && <IconRight className={cn(iconVariants({ size }))} />}
       </div>
       {errorMessage && (
         <Description>

--- a/packages/potion-ui/tailwind.config.js
+++ b/packages/potion-ui/tailwind.config.js
@@ -110,6 +110,10 @@ export default {
           900: "#005C4E",
         },
       },
+      boxShadow: {
+        input:
+          "-2px -2px 0px 0px #E8F4FD, -2px 2px 0px 0px #E8F4FD, 2px -2px 0px 0px #E8F4FD, 2px 2px 0px 0px #E8F4FD",
+      },
     },
   },
   plugins: [],

--- a/packages/potion-ui/tailwind.config.js
+++ b/packages/potion-ui/tailwind.config.js
@@ -113,6 +113,8 @@ export default {
       boxShadow: {
         input:
           "-2px -2px 0px 0px #E8F4FD, -2px 2px 0px 0px #E8F4FD, 2px -2px 0px 0px #E8F4FD, 2px 2px 0px 0px #E8F4FD",
+        "input-error":
+          "-2px -2px 0px 0px #FAEAEA, -2px 2px 0px 0px #FAEAEA, 2px -2px 0px 0px #FAEAEA, 2px 2px 0px 0px #FAEAEA",
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,6 +1215,52 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.5.tgz#102335cac0d22035b04d70ca5ff092d2d1a26f2b"
+  integrity sha512-8GrTWmoFhm5BsMZOTHeGD2/0FLKLQQHvO/ZmQga4tKempYRLz8aqJGqXVuQgisnMObq2YZ2SgkwctN1LOOxcqA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.5"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.8.tgz#45e20532b6d8a061b356a4fb336022cf2609754d"
+  integrity sha512-kx62rP19VZ767Q653wsP1XZCGIirkE09E0QUGNYTM/ttbbQHqcGPdSfWFxUyyNLc/W6aoJRBajOSXhP6GXjC0Q==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.5"
+
+"@floating-ui/react-dom@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.1.tgz#cca58b6b04fc92b4c39288252e285e0422291fb0"
+  integrity sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/react@^0.26.16":
+  version "0.26.20"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.20.tgz#49ae23347666626db8671c2aa2df469bbec7db71"
+  integrity sha512-RixKJJG92fcIsVoqrFr4Onpzh7hlOx4U7NV4aLhMLmtvjZ5oTB/WzXaANYUZATKqXvvW7t9sCxtzejip26N5Ag==
+  dependencies:
+    "@floating-ui/react-dom" "^2.1.1"
+    "@floating-ui/utils" "^0.2.5"
+    tabbable "^6.0.0"
+
+"@floating-ui/utils@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.5.tgz#105c37d9d9620ce69b7f692a20c821bf1ad2cbf9"
+  integrity sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ==
+
+"@headlessui/react@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-2.1.2.tgz#3ca9378d7d0db6aefdb135f957815790786214ef"
+  integrity sha512-Kb3hgk9gRNRcTZktBrKdHhF3xFhYkca1Rk6e1/im2ENf83dgN54orMW0uSKTXFnUpZOUFZ+wcY05LlipwgZIFQ==
+  dependencies:
+    "@floating-ui/react" "^0.26.16"
+    "@react-aria/focus" "^3.17.1"
+    "@react-aria/interactions" "^3.21.3"
+    "@tanstack/react-virtual" "^3.8.1"
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -1370,6 +1416,57 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@react-aria/focus@^3.17.1":
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.18.1.tgz#b54b88e78662549ddae917e3143723c8dd7a4e90"
+  integrity sha512-N0Cy61WCIv+57mbqC7hiZAsB+3rF5n4JKabxUmg/2RTJL6lq7hJ5N4gx75ymKxkN8GnVDwt4pKZah48Wopa5jw==
+  dependencies:
+    "@react-aria/interactions" "^3.22.1"
+    "@react-aria/utils" "^3.25.1"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+    clsx "^2.0.0"
+
+"@react-aria/interactions@^3.21.3", "@react-aria/interactions@^3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.22.1.tgz#f2219a100c886cee383da7be9ae05e9dd940d39a"
+  integrity sha512-5TLzQaDAQQ5C70yG8GInbO4wIylKY67RfTIIwQPGR/4n5OIjbUD8BOj3NuSsuZ/frUPaBXo1VEBBmSO23fxkjw==
+  dependencies:
+    "@react-aria/ssr" "^3.9.5"
+    "@react-aria/utils" "^3.25.1"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/ssr@^3.9.5":
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.5.tgz#775d84f51f90934ff51ae74eeba3728daac1a381"
+  integrity sha512-xEwGKoysu+oXulibNUSkXf8itW0npHHTa6c4AyYeZIJyRoegeteYuFpZUBPtIDE8RfHdNsSmE1ssOkxRnwbkuQ==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@react-aria/utils@^3.25.1":
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.25.1.tgz#f6530ce47aa28617924cc6868b4cf1c113a909c5"
+  integrity sha512-5Uj864e7T5+yj78ZfLnfHqmypLiqW2mN+nsdslog2z5ssunTqjolVeM15ootXskjISlZ7MojLpq97kIC4nlnAw==
+  dependencies:
+    "@react-aria/ssr" "^3.9.5"
+    "@react-stately/utils" "^3.10.2"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+    clsx "^2.0.0"
+
+"@react-stately/utils@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.10.2.tgz#09377f771592ff537c901aa64178cb3a004a916f"
+  integrity sha512-fh6OTQtbeQC0ywp6LJuuKs6tKIgFvt/DlIZEcIpGho6/oZG229UnIk6TUekwxnDbumuYyan6D9EgUtEMmT8UIg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@react-types/shared@^3.24.1":
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.24.1.tgz#fa06cb681d144fce9c515d8bd296d81440a45d25"
+  integrity sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==
 
 "@rollup/pluginutils@^5.0.2", "@rollup/pluginutils@^5.1.0":
   version "5.1.0"
@@ -1827,6 +1924,25 @@
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-8.2.5.tgz#51615b3ca1ee43be7df92e99cd778d0a695d4362"
   integrity sha512-EEOSmW55MeLB3iskf5uUqffsqu003tTta8XQ1Xg8em3gePxPsjqzQtly1Ws5PtRg1Zvt1Zc6NKHwabiVzxothA==
+
+"@swc/helpers@^0.5.0":
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.12.tgz#37aaca95284019eb5d2207101249435659709f4b"
+  integrity sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==
+  dependencies:
+    tslib "^2.4.0"
+
+"@tanstack/react-virtual@^3.8.1":
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.8.3.tgz#3455fd7e259655ab555ac130b5ac59c3eeae98bc"
+  integrity sha512-9ICwbDUUzN99CJIGc373i8NLoj6zFTKI2Hlcmo0+lCSAhPQ5mxq4dGOMKmLYoEFyHcGQ64Bd6ZVbnPpM6lNK5w==
+  dependencies:
+    "@tanstack/virtual-core" "3.8.3"
+
+"@tanstack/virtual-core@3.8.3":
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.8.3.tgz#9db61ab2a96e43d9e035b1cfd82eeede6d52f171"
+  integrity sha512-vd2A2TnM5lbnWZnHi9B+L2gPtkSeOtJOAw358JqokIH1+v2J7vUAzFVPwB/wrye12RFOurffXu33plm4uQ+JBQ==
 
 "@testing-library/dom@10.1.0":
   version "10.1.0"
@@ -2828,7 +2944,7 @@ clsx@2.0.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
   integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
-clsx@^2.1.1:
+clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -5563,6 +5679,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tabbable@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
 tailwind-merge@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.4.0.tgz#1345209dc1f484f15159c9180610130587703042"
@@ -5712,7 +5833,7 @@ tslib@^1.13.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1:
+tslib@^2.0.1, tslib@^2.4.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==


### PR DESCRIPTION
A light wrapper around the native input element that handles tedious accessibility concerns and provides more opinionated states for things like hover and focus.